### PR TITLE
Switch back to abandoned evidence threshold default

### DIFF
--- a/auditree/auditree.template.json
+++ b/auditree/auditree.template.json
@@ -7,7 +7,6 @@
   "org": {
     "auditree": {
       "abandoned_evidence": {
-        "threshold": 0,
         "ignore_history": true
       },
       "repo_integrity": {


### PR DESCRIPTION
* 0 means guaranteed findings on all reports, since they haven't been re-generated yet until after the check is done.
* it was in place to test that the check worked without waiting 30 days the first time

