### PR TITLE
Fix permissions errors when run in github actions

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -9,7 +9,7 @@ python c2p/compliance_to_policy.py -c cdef.json -o auditree/auditree.json
 if [ "$1" = "" ]; then
   ar="$(mktemp -d)/auditree.json"
 else
-  ar="$1"
+  ar="$1/auditree.json"
 fi
 
 python c2p/result_to_compliance.py -c cdef.json -i /tmp/compliance/check_results.json > $ar


### PR DESCRIPTION
# 🎫 Addresses issue: #5 

## 🛠 Summary of changes

* when an argument is provided to check, it is a directory to write a file to, not the filename itself.

## 👀 Screenshots and Evidence

Before:
<img width="512" alt="Screenshot 2024-09-12 at 10 09 10 AM" src="https://github.com/user-attachments/assets/b93fde24-0191-41a7-aa02-42d7a17d3a23">

After: [the test passes and the artifact is downloadable](https://github.com/GSA-TTS/continuous-assessment-poc/actions/runs/10832394513)
