### PR TITLE
Fix GitHub usage and typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for DevTools-flavored applications.
 
 ## Use in your project
 
-1. Create a new github repository to store your auditree evidence and reports. *Important* Add a default README with the gitub UI, so that there is a single commit in the repo before running Auditree.
+1. Create a new GitHub repository to store your auditree evidence and reports. *Important* Add a default README with the GitHub UI, so that there is a single commit in the repo before running Auditree.
 1. Initialize the config file: `docker run --rm ghcr.io/gsa-tts/auditree init > path/to/auditree.template.json`
 1. Edit the generated config to insert the proper repository addresses for both your evidence locker repo and code repo.
 1. TKTK instructions for actual use coming soon.
@@ -14,7 +14,7 @@ for DevTools-flavored applications.
 
 1. Make required changes
 1. Push to GitHub and create a PR
-1. On merging to main, a new docker image will be built, tagged, and pushed to the github container registry.
+1. On merging to main, a new docker image will be built, tagged, and pushed to the GitHub container registry.
 
 Each published image will be tagged with:
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: #0
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

## 🛠 Summary of changes

* Normalized on GitHub capitalization
* Fixed typo

## 📜 Testing Plan

How would a peer test this work?

- Read the README, scanning for non-standard usage of the term "GitHub"

